### PR TITLE
Fix Badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Threeal Bot
 
-[![build status](https://img.shields.io/github/workflow/status/threeal/threeal-bot/build)](https://github.com/threeal/threeal-bot/actions/workflows/build.yml)
+[![build status](https://img.shields.io/github/actions/workflow/status/threeal/threeal-bot/build.yml?branch=main)](https://github.com/threeal/threeal-bot/actions/workflows/build.yml)
 
 A personal multi-purpose bot written in [Go](https://go.dev/).


### PR DESCRIPTION
Fix build badge URL as mentioned in https://github.com/badges/shields/issues/8671.