### PR TITLE
Use Go Generate for Generating Proto

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,10 @@ on:
   workflow_dispatch:
   push:
 jobs:
-  buiild-and-test:
+  build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout this repository
+      - name: Checkout repository
         uses: actions/checkout@v2.5.0
         with:
           fetch-depth: 0
@@ -17,8 +17,8 @@ jobs:
       - name: Generate sources
         run: go generate ./pkg/...
 
-      - name: Build this project
+      - name: Build targets
         run: go build ./cmd/...
 
-      - name: Test this project
+      - name: Run tests
         run: go test ./pkg/...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Install Protobuf
         run: sudo snap install protobuf --classic
 
-      - name: Generate sources from proto files
-        run: make proto
+      - name: Generate sources
+        run: go generate ./pkg/...
 
       - name: Build this project
         run: go build ./cmd/...

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,0 @@
-proto:
-	@protoc \
-		--go_out=. --go_opt=paths=source_relative \
-		--go-grpc_out=. --go-grpc_opt=paths=source_relative \
-		$(shell find . -iname '*.proto')

--- a/pkg/schema/generate.go
+++ b/pkg/schema/generate.go
@@ -1,0 +1,3 @@
+package schema
+
+//go:generate protoc --go_out=. --go-grpc_out=. --go_opt=paths=source_relative --go-grpc_opt=paths=source_relative echo.proto


### PR DESCRIPTION
Use `go generate` command to generate sources from `*.proto` files (replacing `MakeFile`) and implement it on the `build.yml` workflow. This PR also modify a bit words that are used in that workflow.