### PR TITLE
Add `tcp` Package

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -15,8 +15,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to create a new server on `%s`: %v", addr, err)
 	}
-	schema.RegisterEchoServer(server.Srv, &service.EchoServer{})
-	log.Printf("server listening at %v", server.Lis.Addr())
+	schema.RegisterEchoServer(server, &service.EchoServer{})
+	log.Printf("server listening at %v", server.Addr())
 	if err := server.Serve(); err != nil {
 		log.Fatalf("failed to serve: %v", err)
 	}

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -2,25 +2,22 @@ package main
 
 import (
 	"log"
-	"net"
 
 	"github.com/threeal/threeal-bot/pkg/schema"
 	"github.com/threeal/threeal-bot/pkg/service"
+	"github.com/threeal/threeal-bot/pkg/tcp"
 	"github.com/threeal/threeal-bot/pkg/utils"
-
-	"google.golang.org/grpc"
 )
 
 func main() {
 	addr := utils.GetEnvOrDefault("THREEAL_BOT_ADDR", ":50051")
-	lis, err := net.Listen("tcp", addr)
+	server, err := tcp.NewServer(addr)
 	if err != nil {
-		log.Fatalf("failed to listen: %v", err)
+		log.Fatalf("failed to create a new server on `%s`: %v", addr, err)
 	}
-	server := grpc.NewServer()
-	schema.RegisterEchoServer(server, &service.EchoServer{})
-	log.Printf("server listening at %v", lis.Addr())
-	if err := server.Serve(lis); err != nil {
+	schema.RegisterEchoServer(server.Srv, &service.EchoServer{})
+	log.Printf("server listening at %v", server.Lis.Addr())
+	if err := server.Serve(); err != nil {
 		log.Fatalf("failed to serve: %v", err)
 	}
 }

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"github.com/threeal/threeal-bot/pkg/cli"
+	"github.com/threeal/threeal-bot/pkg/tcp"
 	"github.com/threeal/threeal-bot/pkg/utils"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 func getClient(key string, conn grpc.ClientConnInterface) cli.Client {
@@ -23,7 +23,7 @@ func getClient(key string, conn grpc.ClientConnInterface) cli.Client {
 func main() {
 	flag.Parse()
 	addr := utils.GetEnvOrDefault("THREEAL_BOT_ADDR", "localhost:50051")
-	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := tcp.Connect(addr)
 	if err != nil {
 		log.Fatalf("failed to connect: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,18 @@ module github.com/threeal/threeal-bot
 go 1.19
 
 require (
+	github.com/stretchr/testify v1.8.1
 	google.golang.org/grpc v1.51.0
 	google.golang.org/protobuf v1.28.1
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	golang.org/x/text v0.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/threeal/threeal-bot
 go 1.19
 
 require (
+	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/stretchr/testify v1.8.1
 	google.golang.org/grpc v1.51.0
 	google.golang.org/protobuf v1.28.1

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,9 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -23,7 +26,16 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -74,5 +86,10 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5 h1:Ii+DKncOVM8Cu1Hc+ETb5K+23HdAMvESYE3ZJ5b5cMI=
+github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/pkg/cli/echo_test.go
+++ b/pkg/cli/echo_test.go
@@ -6,11 +6,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/threeal/threeal-bot/pkg/schema"
 	"github.com/threeal/threeal-bot/pkg/service"
 	"github.com/threeal/threeal-bot/pkg/tcp"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 func TestEchoClient(t *testing.T) {
@@ -19,10 +18,9 @@ func TestEchoClient(t *testing.T) {
 	schema.RegisterEchoServer(server, &service.EchoServer{})
 	go func() { server.Serve() }()
 	time.Sleep(30 * time.Millisecond)
-	conn, err := grpc.Dial("localhost:50050", grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		t.Fatalf("failed to connect to 'localhost:50050': %v", err)
-	}
+	conn, err := tcp.Connect("localhost:50050")
+	require.NoError(t, err)
+	defer conn.Close()
 	client := NewEchoClient(conn)
 	t.Run("Call", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/pkg/cli/echo_test.go
+++ b/pkg/cli/echo_test.go
@@ -2,9 +2,11 @@ package cli
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
+	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/require"
 	"github.com/threeal/threeal-bot/pkg/schema"
 	"github.com/threeal/threeal-bot/pkg/service"
@@ -12,13 +14,15 @@ import (
 )
 
 func TestEchoClient(t *testing.T) {
-	server, err := tcp.NewServer(":50050")
+	port, err := freeport.GetFreePort()
+	require.NoError(t, err)
+	server, err := tcp.NewServer(":" + strconv.Itoa(port))
 	require.NoError(t, err)
 	schema.RegisterEchoServer(server, &service.EchoServer{})
 	go func() { server.Serve() }()
 	defer server.Stop()
 	time.Sleep(30 * time.Millisecond)
-	conn, err := tcp.Connect("localhost:50050")
+	conn, err := tcp.Connect("localhost:" + strconv.Itoa(port))
 	require.NoError(t, err)
 	defer conn.Close()
 	client := NewEchoClient(conn)

--- a/pkg/cli/echo_test.go
+++ b/pkg/cli/echo_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/threeal/threeal-bot/pkg/schema"
 	"github.com/threeal/threeal-bot/pkg/service"
@@ -14,9 +13,10 @@ import (
 
 func TestEchoClient(t *testing.T) {
 	server, err := tcp.NewServer(":50050")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	schema.RegisterEchoServer(server, &service.EchoServer{})
 	go func() { server.Serve() }()
+	defer server.Stop()
 	time.Sleep(30 * time.Millisecond)
 	conn, err := tcp.Connect("localhost:50050")
 	require.NoError(t, err)

--- a/pkg/cli/echo_test.go
+++ b/pkg/cli/echo_test.go
@@ -2,25 +2,23 @@ package cli
 
 import (
 	"context"
-	"net"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/threeal/threeal-bot/pkg/schema"
 	"github.com/threeal/threeal-bot/pkg/service"
+	"github.com/threeal/threeal-bot/pkg/tcp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
 func TestEchoClient(t *testing.T) {
-	lis, err := net.Listen("tcp", ":50050")
-	if err != nil {
-		t.Fatalf("failed to listen to ':50050': %v", err)
-	}
-	server := grpc.NewServer()
+	server, err := tcp.NewServer(":50050")
+	assert.NoError(t, err)
 	schema.RegisterEchoServer(server, &service.EchoServer{})
-	go func() { server.Serve(lis) }()
-	time.Sleep(100 * time.Millisecond)
+	go func() { server.Serve() }()
+	time.Sleep(30 * time.Millisecond)
 	conn, err := grpc.Dial("localhost:50050", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("failed to connect to 'localhost:50050': %v", err)

--- a/pkg/service/echo_test.go
+++ b/pkg/service/echo_test.go
@@ -2,22 +2,26 @@ package service
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
+	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/require"
 	"github.com/threeal/threeal-bot/pkg/schema"
 	"github.com/threeal/threeal-bot/pkg/tcp"
 )
 
 func TestEchoServer(t *testing.T) {
-	server, err := tcp.NewServer(":50050")
+	port, err := freeport.GetFreePort()
+	require.NoError(t, err)
+	server, err := tcp.NewServer(":" + strconv.Itoa(port))
 	require.NoError(t, err)
 	schema.RegisterEchoServer(server, &EchoServer{})
 	go func() { server.Serve() }()
 	defer server.Stop()
 	time.Sleep(30 * time.Millisecond)
-	conn, err := tcp.Connect("localhost:50050")
+	conn, err := tcp.Connect("localhost:" + strconv.Itoa(port))
 	require.NoError(t, err)
 	defer conn.Close()
 	client := schema.NewEchoClient(conn)

--- a/pkg/service/echo_test.go
+++ b/pkg/service/echo_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/threeal/threeal-bot/pkg/schema"
 	"github.com/threeal/threeal-bot/pkg/tcp"
@@ -13,9 +12,10 @@ import (
 
 func TestEchoServer(t *testing.T) {
 	server, err := tcp.NewServer(":50050")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	schema.RegisterEchoServer(server, &EchoServer{})
 	go func() { server.Serve() }()
+	defer server.Stop()
 	time.Sleep(30 * time.Millisecond)
 	conn, err := tcp.Connect("localhost:50050")
 	require.NoError(t, err)

--- a/pkg/service/echo_test.go
+++ b/pkg/service/echo_test.go
@@ -2,24 +2,22 @@ package service
 
 import (
 	"context"
-	"net"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/threeal/threeal-bot/pkg/schema"
+	"github.com/threeal/threeal-bot/pkg/tcp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
 func TestEchoServer(t *testing.T) {
-	lis, err := net.Listen("tcp", ":50050")
-	if err != nil {
-		t.Fatalf("failed to listen to ':50050': %v", err)
-	}
-	server := grpc.NewServer()
+	server, err := tcp.NewServer(":50050")
+	assert.NoError(t, err)
 	schema.RegisterEchoServer(server, &EchoServer{})
-	go func() { server.Serve(lis) }()
-	time.Sleep(100 * time.Millisecond)
+	go func() { server.Serve() }()
+	time.Sleep(30 * time.Millisecond)
 	conn, err := grpc.Dial("localhost:50050", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("failed to connect to 'localhost:50050': %v", err)

--- a/pkg/service/echo_test.go
+++ b/pkg/service/echo_test.go
@@ -6,10 +6,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/threeal/threeal-bot/pkg/schema"
 	"github.com/threeal/threeal-bot/pkg/tcp"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 func TestEchoServer(t *testing.T) {
@@ -18,10 +17,9 @@ func TestEchoServer(t *testing.T) {
 	schema.RegisterEchoServer(server, &EchoServer{})
 	go func() { server.Serve() }()
 	time.Sleep(30 * time.Millisecond)
-	conn, err := grpc.Dial("localhost:50050", grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		t.Fatalf("failed to connect to 'localhost:50050': %v", err)
-	}
+	conn, err := tcp.Connect("localhost:50050")
+	require.NoError(t, err)
+	defer conn.Close()
 	client := schema.NewEchoClient(conn)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/pkg/tcp/connect.go
+++ b/pkg/tcp/connect.go
@@ -1,0 +1,10 @@
+package tcp
+
+import (
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func Connect(address string) (*grpc.ClientConn, error) {
+	return grpc.Dial(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+}

--- a/pkg/tcp/connect_test.go
+++ b/pkg/tcp/connect_test.go
@@ -10,7 +10,7 @@ func TestConnect(t *testing.T) {
 	server, err := NewServer(":50050")
 	require.NoError(t, err)
 	go func() { server.Serve() }()
-	defer server.GracefulStop()
+	defer server.Stop()
 	conn, err := Connect("localhost:50050")
 	require.NoError(t, err)
 	require.NotNil(t, conn)

--- a/pkg/tcp/connect_test.go
+++ b/pkg/tcp/connect_test.go
@@ -1,0 +1,19 @@
+package tcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnect(t *testing.T) {
+	server, err := NewServer(":50050")
+	require.NoError(t, err)
+	go func() { server.Serve() }()
+	defer server.GracefulStop()
+	conn, err := Connect("localhost:50050")
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	err = conn.Close()
+	require.NoError(t, err)
+}

--- a/pkg/tcp/connect_test.go
+++ b/pkg/tcp/connect_test.go
@@ -1,17 +1,21 @@
 package tcp
 
 import (
+	"strconv"
 	"testing"
 
+	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/require"
 )
 
 func TestConnect(t *testing.T) {
-	server, err := NewServer(":50050")
+	port, err := freeport.GetFreePort()
+	require.NoError(t, err)
+	server, err := NewServer(":" + strconv.Itoa(port))
 	require.NoError(t, err)
 	go func() { server.Serve() }()
 	defer server.Stop()
-	conn, err := Connect("localhost:50050")
+	conn, err := Connect("localhost:" + strconv.Itoa(port))
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 	err = conn.Close()

--- a/pkg/tcp/server.go
+++ b/pkg/tcp/server.go
@@ -7,12 +7,12 @@ import (
 )
 
 type Server struct {
-	listener net.Listener
-	server   *grpc.Server
+	Lis net.Listener
+	Srv *grpc.Server
 }
 
 func (s *Server) Serve() error {
-	return s.server.Serve(s.listener)
+	return s.Srv.Serve(s.Lis)
 }
 
 func NewServer(address string) (*Server, error) {
@@ -20,6 +20,6 @@ func NewServer(address string) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	server := &Server{listener: lis, server: grpc.NewServer()}
+	server := &Server{Lis: lis, Srv: grpc.NewServer()}
 	return server, nil
 }

--- a/pkg/tcp/server.go
+++ b/pkg/tcp/server.go
@@ -1,0 +1,25 @@
+package tcp
+
+import (
+	"net"
+
+	"google.golang.org/grpc"
+)
+
+type Server struct {
+	listener net.Listener
+	server   *grpc.Server
+}
+
+func (s *Server) Serve() error {
+	return s.server.Serve(s.listener)
+}
+
+func NewServer(address string) (*Server, error) {
+	lis, err := net.Listen("tcp", address)
+	if err != nil {
+		return nil, err
+	}
+	server := &Server{listener: lis, server: grpc.NewServer()}
+	return server, nil
+}

--- a/pkg/tcp/server.go
+++ b/pkg/tcp/server.go
@@ -7,12 +7,12 @@ import (
 )
 
 type Server struct {
-	Lis net.Listener
-	Srv *grpc.Server
+	*grpc.Server
+	net.Listener
 }
 
 func (s *Server) Serve() error {
-	return s.Srv.Serve(s.Lis)
+	return s.Server.Serve(s.Listener)
 }
 
 func NewServer(address string) (*Server, error) {
@@ -20,6 +20,6 @@ func NewServer(address string) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	server := &Server{Lis: lis, Srv: grpc.NewServer()}
+	server := &Server{grpc.NewServer(), lis}
 	return server, nil
 }

--- a/pkg/tcp/server_test.go
+++ b/pkg/tcp/server_test.go
@@ -1,0 +1,33 @@
+package tcp
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestServer(t *testing.T) {
+	t.Run("NewServer", func(t *testing.T) {
+		server, err := NewServer(":50050")
+		if err != nil {
+			t.Fatalf("failed to create a new server on `:50050`: %v", err)
+		}
+		if server == nil {
+			t.Fatal("Expected `server` to be non-nil, got nil instead")
+		}
+		t.Run("Serve", func(t *testing.T) {
+			res := make(chan error)
+			go func() { res <- server.Serve() }()
+			server.server.GracefulStop()
+			err = <-res
+			if !strings.Contains(err.Error(), "the server has been stopped") {
+				t.Fatalf("failed during serving the server: %v", err)
+			}
+		})
+	})
+	t.Run("NewServerFailure", func(t *testing.T) {
+		_, err := NewServer("invalid")
+		if err == nil {
+			t.Fatal("Expected `err` to be non-nil, got nil instead")
+		}
+	})
+}

--- a/pkg/tcp/server_test.go
+++ b/pkg/tcp/server_test.go
@@ -1,14 +1,18 @@
 package tcp
 
 import (
+	"strconv"
 	"testing"
 
+	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/require"
 )
 
 func TestServer(t *testing.T) {
 	t.Run("NewServer", func(t *testing.T) {
-		server, err := NewServer(":50050")
+		port, err := freeport.GetFreePort()
+		require.NoError(t, err)
+		server, err := NewServer(":" + strconv.Itoa(port))
 		require.NoError(t, err)
 		require.NotNil(t, server)
 		t.Run("Serve", func(t *testing.T) {

--- a/pkg/tcp/server_test.go
+++ b/pkg/tcp/server_test.go
@@ -17,7 +17,7 @@ func TestServer(t *testing.T) {
 		t.Run("Serve", func(t *testing.T) {
 			res := make(chan error)
 			go func() { res <- server.Serve() }()
-			server.server.GracefulStop()
+			server.Srv.GracefulStop()
 			err = <-res
 			if !strings.Contains(err.Error(), "the server has been stopped") {
 				t.Fatalf("failed during serving the server: %v", err)

--- a/pkg/tcp/server_test.go
+++ b/pkg/tcp/server_test.go
@@ -17,7 +17,7 @@ func TestServer(t *testing.T) {
 		t.Run("Serve", func(t *testing.T) {
 			res := make(chan error)
 			go func() { res <- server.Serve() }()
-			server.Srv.GracefulStop()
+			server.GracefulStop()
 			err = <-res
 			if !strings.Contains(err.Error(), "the server has been stopped") {
 				t.Fatalf("failed during serving the server: %v", err)

--- a/pkg/tcp/server_test.go
+++ b/pkg/tcp/server_test.go
@@ -3,24 +3,24 @@ package tcp
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServer(t *testing.T) {
 	t.Run("NewServer", func(t *testing.T) {
 		server, err := NewServer(":50050")
-		assert.NoError(t, err)
-		assert.NotNil(t, server)
+		require.NoError(t, err)
+		require.NotNil(t, server)
 		t.Run("Serve", func(t *testing.T) {
 			res := make(chan error)
 			go func() { res <- server.Serve() }()
 			server.GracefulStop()
 			err = <-res
-			assert.ErrorContains(t, err, "the server has been stopped")
+			require.ErrorContains(t, err, "the server has been stopped")
 		})
 	})
 	t.Run("NewServerFailure", func(t *testing.T) {
 		_, err := NewServer("invalid")
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }

--- a/pkg/tcp/server_test.go
+++ b/pkg/tcp/server_test.go
@@ -1,33 +1,26 @@
 package tcp
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestServer(t *testing.T) {
 	t.Run("NewServer", func(t *testing.T) {
 		server, err := NewServer(":50050")
-		if err != nil {
-			t.Fatalf("failed to create a new server on `:50050`: %v", err)
-		}
-		if server == nil {
-			t.Fatal("Expected `server` to be non-nil, got nil instead")
-		}
+		assert.NoError(t, err)
+		assert.NotNil(t, server)
 		t.Run("Serve", func(t *testing.T) {
 			res := make(chan error)
 			go func() { res <- server.Serve() }()
 			server.GracefulStop()
 			err = <-res
-			if !strings.Contains(err.Error(), "the server has been stopped") {
-				t.Fatalf("failed during serving the server: %v", err)
-			}
+			assert.ErrorContains(t, err, "the server has been stopped")
 		})
 	})
 	t.Run("NewServerFailure", func(t *testing.T) {
 		_, err := NewServer("invalid")
-		if err == nil {
-			t.Fatal("Expected `err` to be non-nil, got nil instead")
-		}
+		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
Add `tcp` package which simplify TCP server creation and connection. Functions from this package then implemented across other packages inside this code.

Aside from that, this PR also introduce [Testify](https://pkg.go.dev/github.com/stretchr/testify) as a dependency to simplify unit test assertion and [FreePort](https://github.com/phayes/freeport) as a dependency to obtain open port during testing.