### PR TITLE
Audit Workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
 
   send-coverage-info:
     needs: build-and-test
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Download the artifact of code coverage info
@@ -59,6 +60,7 @@ jobs:
 
   send-test-results:
     needs: build-and-test
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Download the artifact of test results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,6 @@ jobs:
         run: |
           ./testspace config url ${{ secrets.TESTSPACE_URL }}
           ./testspace config project ${{ secrets.TESTSPACE_PROJECT }}
-          ./testspace config space ${{ github.ref_name }}
 
       - name: Send test results to Testspace
         run: ./testspace [Tests]"test.xml"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   workflow_dispatch:
   pull_request:
   push:
+    branches: [main]
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,21 +28,33 @@ jobs:
       - name: Generate summary of test results
         run: ~/go/bin/gotestsum --junitfile build/test.xml
 
-      - name: Download Testspace client
-        run: curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | tar -zxvf- -C build
-
-      - name: Configure Testspace client
-        working-directory: build
-        run: |
-          ./testspace config url ${{ secrets.TESTSPACE_URL }}
-          ./testspace config project ${{ secrets.TESTSPACE_PROJECT }}
-          ./testspace config space ${{ github.ref_name }}
-
-      - name: Send summary of test results to Testspace
-        working-directory: build
-        run: ./testspace [Tests]"test.xml"
+      - name: Upload test results as an artifact
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: test-results
+          path: build/test.xml
 
       - name: Send code coverage info to Coveralls
         uses: shogo82148/actions-goveralls@v1.6.0
         with:
           path-to-profile: profile.cov
+
+  send-test-results:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download the artifact of test results
+        uses: actions/download-artifact@v3.0.2
+        with:
+          name: test-results
+
+      - name: Download a Testspace client
+        run: curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | tar -zxvf-
+
+      - name: Configure the Testspace client
+        run: |
+          ./testspace config url ${{ secrets.TESTSPACE_URL }}
+          ./testspace config project ${{ secrets.TESTSPACE_PROJECT }}
+          ./testspace config space ${{ github.ref_name }}
+
+      - name: Send test results to Testspace
+        run: ./testspace [Tests]"test.xml"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: build
 on:
   workflow_dispatch:
+  pull_request:
   push:
 jobs:
   build-and-test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Run tests
         run: go test -covermode atomic -coverprofile=profile.cov ./pkg/...
 
+      - name: Upload the code coverage info as an artifact
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: coverage-info
+          path: profile.cov
+
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
 
@@ -34,7 +40,16 @@ jobs:
           name: test-results
           path: build/test.xml
 
-      - name: Send code coverage info to Coveralls
+  send-coverage-info:
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download the artifact of code coverage info
+        uses: actions/download-artifact@v3.0.2
+        with:
+          name: coverage-info
+
+      - name: Send the code coverage info to Coveralls
         uses: shogo82148/actions-goveralls@v1.6.0
         with:
           path-to-profile: profile.cov

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,8 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout this repository
         uses: actions/checkout@v3.3.0
-        with:
-          fetch-depth: 0
 
       - name: Install Protobuf
         run: sudo snap install protobuf --classic

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,10 @@ jobs:
         uses: actions/upload-artifact@v3.1.2
         with:
           name: coverage-info
-          path: profile.cov
+          path: |
+            pkg/**/*.go
+            go.mod
+            profile.cov
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
           path-to-profile: profile.cov
 
   send-test-results:
+    needs: build-and-test
     runs-on: ubuntu-latest
     steps:
       - name: Download the artifact of test results


### PR DESCRIPTION
Now sending test results to [Testspace ](http://testspace.com/) and sending coverage info to [Coveralls ](https://coveralls.io/) are separate jobs. Both use [Upload Artifact](https://github.com/marketplace/actions/upload-a-build-artifact) and [Download Artifact](https://github.com/marketplace/actions/download-a-build-artifact) action to pass file between jobs.

Aside from that, this PR also modify how the `build.yml` action got triggered. Now it will be triggered by pull request on any branch and push on main. When triggered by pull request, both test results and coverage info won't be send to third party providers.

Last, this PR also remove `fetch-depth` input when using the [Checkout Action](https://github.com/marketplace/actions/checkout).
