### PR TITLE
Include `.git` Directory for Coveralls Upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           name: coverage-info
           path: |
+            .git/
             pkg/**/*.go
             go.mod
             profile.cov


### PR DESCRIPTION
Closes #27.

See [this](https://coveralls.io/builds/56374883) for the report info.