### PR TITLE
Ignore Dotfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.*
+!.git*
+
 build
 profile.cov
 test.xml


### PR DESCRIPTION
Ignore all files which prefixed with dot (`.*`), except [Git](https://git-scm.com/) files (`.git*`).